### PR TITLE
[security vulnerability] fix vulnerability.

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -75,10 +75,25 @@ void ThreadLinkInfo::SetFrom(const Mac::RxFrame &aFrame)
         mIsDstPanIdBroadcast = (dstPanId == Mac::kPanIdBroadcast);
     }
 
-    mChannel      = aFrame.GetChannel();
-    mRss          = aFrame.GetRssi();
-    mLqi          = aFrame.GetLqi();
-    mLinkSecurity = aFrame.GetSecurityEnabled();
+    if (aFrame.GetSecurityEnabled())
+    {
+        uint8_t keyIdMode;
+
+        // MAC Frame Security was already validated at the MAC
+        // layer. As a result, `GetKeyIdMode()` will never return
+        // failure here.
+        IgnoreError(aFrame.GetKeyIdMode(keyIdMode));
+
+        mLinkSecurity = (keyIdMode == Mac::Frame::kKeyIdMode0) || (keyIdMode == Mac::Frame::kKeyIdMode1);
+    }
+    else
+    {
+        mLinkSecurity = false;
+    }
+
+    mChannel = aFrame.GetChannel();
+    mRss = aFrame.GetRssi();
+    mLqi = aFrame.GetLqi();
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     if (aFrame.GetTimeIe() != nullptr)
     {


### PR DESCRIPTION
- The vulnerability allows an attacker in physical proximity to inject arbitrary IPv6 packets into the Thread network via IEEE 802.15.4 frame transmissions.
- Thread devices use MAC Key ID Mode 2 when communicating some messages. The key used for this mode is pre-defined and openly specified. As such, the Thread Specification requires devices to enforce specific processing of such messages as if they are unsecured at the MAC layer. However, OpenThread did not enforce this properly.

Created from patch authored by Jonathan Hui